### PR TITLE
Update composer dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,6 @@
 	],
 	"require": {
 		"composer/installers": "~1.0",
-		"silverstripe-australia/gridfieldextensions": "~1.0"
+		"symbiote/silverstripe-gridfieldextensions": "~1.0"
 	}
 }


### PR DESCRIPTION
Package silverstripe-australia/gridfieldextensions is abandoned, you should avoid using it. Use symbiote/silverstripe-gridfieldextensions instead.