### PR TITLE
Update gridfieldextensions version to 2.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,6 @@
 	],
 	"require": {
 		"composer/installers": "~1.0",
-		"symbiote/silverstripe-gridfieldextensions": "~1.0"
+		"symbiote/silverstripe-gridfieldextensions": "~2.0"
 	}
 }


### PR DESCRIPTION
When the vendor name was changed they moved to 2.x release, there were no 'major' code changes